### PR TITLE
Move login and signup to page start

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -26,6 +26,8 @@ const App = () => (
           <Route path="/become-mentor" element={<BecomeMentor />} />
           <Route path="/chat/:mentorId" element={<Chat />} />
           <Route path="/auth" element={<Auth />} />
+          <Route path="/signin" element={<Auth />} />
+          <Route path="/signup" element={<Auth />} />
           {/* ADD ALL CUSTOM ROUTES ABOVE THE CATCH-ALL "*" ROUTE */}
           <Route path="*" element={<NotFound />} />
         </Routes>

--- a/src/pages/Auth.tsx
+++ b/src/pages/Auth.tsx
@@ -125,7 +125,7 @@ const Auth = () => {
   }
 
   return (
-    <div className="min-h-screen bg-gradient-to-br from-background to-muted flex items-center justify-center p-4">
+    <div className="min-h-screen bg-gradient-to-br from-background to-muted flex items-start justify-center p-4">
       <Card className="w-full max-w-md shadow-warm">
         <CardHeader className="text-center">
           <div className="flex justify-center mb-4">


### PR DESCRIPTION
Move login/signup card to the top of the page and add `/signin` and `/signup` routes.

The user requested the login and signup forms to appear at the beginning of the page rather than in the middle. The routes were added for direct access to the authentication page.

---
<a href="https://cursor.com/background-agent?bcId=bc-ef2749e7-85af-4fcf-8a3e-3d1f1851afee">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-ef2749e7-85af-4fcf-8a3e-3d1f1851afee">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

